### PR TITLE
Prevent misleading results due to VM optimizations

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ function record(name, count, fn) {
   let diff = hd.end();
   let total = diff.change.size_bytes;
   console.log(row(name, prettyBytes(total / count), String(count), prettyBytes(total)));
+  return arr;
 }
 
 function fill(count, obj, fn) {


### PR DESCRIPTION
Just a hypothesis, but V8 appears to be optimizing memory allocation on the basis that the array is never used again after the main loop has executed, which allows it to release memory prematurely, resulting in a misleading allocation profile in the results. Setting the array as the function's return value forces the VM to stop optimizing away the allocated memory you're trying to profile, leading to very different results than what you published.

Setting the array as the function's return value gives me these results:

```
|                           kind | total/n    |          n |      total |
-------------------------------------------------------------------------
|                         number | 11.6 B     |    1000000 |    11.6 MB |
|                   empty string | 11.6 B     |    1000000 |    11.6 MB |
|                           true | 11.7 B     |    1000000 |    11.7 MB |
|                   empty object | 67.7 B     |    1000000 |    67.7 MB |
|                    empty array | 91.7 B     |    1000000 |    91.7 MB |
|                      empty map | 196 B      |    1000000 |     196 MB |
|                      empty set | 164 B      |    1000000 |     164 MB |
|                  empty weakmap | 156 B      |    1000000 |     156 MB |
|                  empty weakset | 156 B      |    1000000 |     156 MB |
|            Object.create(null) | 188 B      |    1000000 |     188 MB |
|                 10 item object | 218 B      |     100000 |    21.8 MB |
|                100 item object | 1.2 kB     |      10000 |      12 MB |
|               1000 item object | 10.4 kB    |       1000 |    10.4 MB |
|                  10 item array | 242 B      |     100000 |    24.2 MB |
|                 100 item array | 1.34 kB    |      10000 |    13.4 MB |
|                1000 item array | 11.6 kB    |       1000 |    11.6 MB |
|                    10 item map | 530 B      |     100000 |      53 MB |
|                   100 item map | 3.67 kB    |      10000 |    36.7 MB |
|                  1000 item map | 28.8 kB    |       1000 |    28.8 MB |
|                    10 item set | 402 B      |     100000 |    40.2 MB |
|                   100 item set | 2.64 kB    |      10000 |    26.4 MB |
|                  1000 item set | 20.6 kB    |       1000 |    20.6 MB |
|         10 item object defProp | 738 B      |     100000 |    73.8 MB |
|        100 item object defProp | 8.66 kB    |      10000 |    86.6 MB |
|       1000 item object defProp | 73.3 kB    |       1000 |    73.3 MB |
|     10 item object defProp ref | 738 B      |     100000 |    73.8 MB |
|    100 item object defProp ref | 8.66 kB    |      10000 |    86.6 MB |
|   1000 item object defProp ref | 73.3 kB    |       1000 |    73.3 MB |
|      10 item object shared obj | 218 B      |     100000 |    21.8 MB |
|     100 item object shared obj | 1.2 kB     |      10000 |      12 MB |
|    1000 item object shared obj | 10.4 kB    |       1000 |    10.4 MB |
|              10 item arr mixed | 419 B      |     100000 |    41.9 MB |
|             100 item arr mixed | 3.54 kB    |      10000 |    35.4 MB |
|            1000 item arr mixed | 33.6 kB    |       1000 |    33.6 MB |
```

This was run against node v9.11.1.